### PR TITLE
Fix installation instruction on archlinux

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -128,11 +128,11 @@ Examples:
 
 - **Aura**:
   ```
-  sudo aura -A vscodium
+  sudo aura -A vscodium-bin
   ```
 - **Yay**:
   ```
-  sudo yay -S vscodium
+  yay -S vscodium-bin
   ```
 
 ### <a id="flatpak"></a>Flatpak Option (Linux)


### PR DESCRIPTION
Problems:
- There's no vscodium package on aur repository
- Running yay with root caused a warning, i believe that's not how you supposed to do it
references:
https://wiki.archlinux.org/index.php/Makepkg#Usage
https://github.com/fosskers/aura/blob/a5fc961b3f1e8964a49fa69201c56bf11a88498b/README.org#run-as-root-build-as-a-user