### PR TITLE
Remove `sudo` from Arch Linux `yay` install example

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -132,7 +132,7 @@ Examples:
   ```
 - **Yay**:
   ```
-  sudo yay -S vscodium
+  yay -S vscodium
   ```
 
 ### <a id="flatpak"></a>Flatpak Option (Linux)


### PR DESCRIPTION
`yay` shouldn't be run as root & doing so yields the following error:
```Please avoid running yay as root/sudo.```

Instead, `yay` will automatically run `pacman` as root after building packages as an unprivileged user.