### PR TITLE
Split scoop commands in to seperate snippets

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -35,6 +35,8 @@ choco install vscodium
 If you use Windows and have [Scoop](https://scoop.sh/) installed:
 ```bash
 scoop bucket add extras
+```
+```bash
 scoop install vscodium
 ```
 


### PR DESCRIPTION
This jekyll theme seems to only allow single line code snippets.
This commits works around this by splitting them up in two different snippets.