### PR TITLE
fixes vscodium.github.io#19

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -132,7 +132,7 @@ Examples:
   ```
 - **Yay**:
   ```
-  sudo yay -S vscodium
+  yay -S vscodium-bin
   ```
 
 ### <a id="flatpak"></a>Flatpak Option (Linux)


### PR DESCRIPTION
The install instructions for Arch Linux icorrectly instructs the user to use `sudo` and the package name is actually `vscodium-bin`.