### PR TITLE
Remove deprecated apt-key usage

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -68,7 +68,7 @@ sudo apt update && sudo apt install vscodium
 #### Debian / Ubuntu (deb package):
 Add the GPG key of the repository:
 ```bash
-wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg | sudo apt-key add -
+wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/vscodium.gpg
 ```
  
 Add the repository:


### PR DESCRIPTION
Per upstream and Debian error messages, the use of apt-key is deprecated. The new solution in this PR is adapted from the documentation of the upstream repo. 

https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/tree/master