### PR TITLE
corrected the macOS install instruction

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -18,7 +18,7 @@ color: black
 ### Install with Brew (Mac)
 If you are on a Mac and have [Homebrew](https://brew.sh/) installed:
 ```bash
-brew cask install vscodium
+brew install --cask vscodium
 ```
 
 ---


### PR DESCRIPTION
Hi ! I found that the install instruction for MacOS doesn't work and I had to change it into 

```
brew install --cask vscodium
```

for it to work.