### PR TITLE
Update Flatpak instructions

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -144,9 +144,8 @@ Examples:
   ```
 
 ### <a tabindex="-1" aria-hidden="true" id="flatpak" href="#flatpak"></a>Flatpak Option (Linux)
-VSCodium is (unofficially) available as a [Flatpak app](https://flathub.org/apps/details/com.vscodium.codium) and here's the [build repo](https://github.com/flathub/com.vscodium.codium). If your distribution has support for [flatpak](https://flathub.org), and you have enabled the [flathub repo](https://flatpak.org/setup/):
+VSCodium is (unofficially) available as a [Flatpak app](https://flathub.org/apps/details/com.vscodium.codium) and here's the [build repo](https://github.com/flathub/com.vscodium.codium). If your distribution has support for [flatpak](https://flathub.org), and you have enabled the [flathub repo](https://flatpak.org/setup/), you can install VSCodium via the command line:
 ```bash
 flatpak install flathub com.vscodium.codium
-
-flatpak run com.vscodium.codium
 ```
+…or by opening the [flatpakref](https://dl.flathub.org/repo/appstream/com.vscodium.codium.flatpakref) file from [Flathub](https://flathub.org/apps/details/com.vscodium.codium). VSCodium can also be found in GNOME Software if you have `gnome-software-plugin-flatpak` installed (as recommended in the Flathub setup instructions).


### PR DESCRIPTION
The two-line bash block was rendering as a single line, which obviously doesn't doesn't work if you paste it into the terminal:

<img width="883" alt="two-line bash block rendering as a single line" src="https://user-images.githubusercontent.com/9206310/112081329-dd889c80-8b59-11eb-8748-c99c39470f35.png">

I don't know if it's necessary to show the `flatpak run …` command in the install instructions, even if Flatpak doesn't add `vscodium` to the `$PATH`, since Flatpak will set up a `.desktop` file regardless.
