### PR TITLE
use rpmkeys(8) for importing GPG key

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -90,7 +90,7 @@ sudo apt update && sudo apt install codium
 Add the GPG key of the repository:
 
 ```bash
-sudo rpm --import https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/raw/master/pub.gpg
+sudo rpmkeys --import https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/raw/master/pub.gpg
 ```
 
 Add the repository:


### PR DESCRIPTION
Although `rpm --import` works, it isn't listed in rpm(8)'s manpage or usage info.