### PR TITLE
Use `extrepo` to add Debian repo

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -75,23 +75,22 @@ sudo apt update && sudo apt install codium
 [@paulcarroty](https://github.com/paulcarroty) has set up a [repository](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo) for VSCodium. The instructions below are adapted from there. Any issues installing VSCodium using your package manager should be directed to that repository's issue tracker.
 
 #### Debian / Ubuntu (deb package):
-Add the GPG key of the repository:
-```bash
-wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg \
-    | gpg --dearmor \
-    | sudo dd of=/usr/share/keyrings/vscodium-archive-keyring.gpg
+Install extrepo:
+```sh
+sudo apt install extrepo
 ```
- 
+
 Add the repository:
-```bash
-echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg ] https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs vscodium main' \
-    | sudo tee /etc/apt/sources.list.d/vscodium.list
+```sh
+sudo extrepo enable vscodium
 ```
 
 Update then install vscodium:
-```bash
+```sh
 sudo apt update && sudo apt install codium
 ```
+
+If your Debian / Ubuntu version does not ship `extrepo`, you'll have to add the repository manually, as shown [here](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo#option-1-recommended)
 
 
 ---


### PR DESCRIPTION
`extrepo` is a package that contains a curated list of third-party Debian repos. It simplifies adding third party repositories, and it does that in a secure manner.