### PR TITLE
Make code snippets ready for copy+pasting

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -77,14 +77,14 @@ sudo apt update && sudo apt install codium
 #### Debian / Ubuntu (deb package):
 Add the GPG key of the repository:
 ```bash
-wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg \
-    | gpg --dearmor \
+wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
+    | gpg --dearmor
     | sudo dd of=/usr/share/keyrings/vscodium-archive-keyring.gpg
 ```
  
 Add the repository:
 ```bash
-echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg ] https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs vscodium main' \
+echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg ] https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs vscodium main'
     | sudo tee /etc/apt/sources.list.d/vscodium.list
 ```
 


### PR DESCRIPTION
The backslashes are unnecessary for the likely typical use on the website, which is copying the snippets to paste them into the terminal for execution.