### PR TITLE
Maintain line breaks in code snippets on website

### DIFF
--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -270,8 +270,6 @@
 .highlight {
   color: #f8f8f2;
   table-layout: fixed;
-  white-space: nowrap;
-  width:90%;
 }
 
 .highlight pre, .highlight code { display:block; margin:0; padding:0; background: none; overflow:auto; word-wrap: normal; }

--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -77,11 +77,11 @@ sudo apt update && sudo apt install codium
 #### Debian / Ubuntu (deb package):
 Add the GPG key of the repository:
 ```bash
-wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
-    | gpg --dearmor
+wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg \
+    | gpg --dearmor \
     | sudo dd of=/usr/share/keyrings/vscodium-archive-keyring.gpg
 ```
- 
+
 Add the repository:
 ```bash
 echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg ] https://download.vscodium.com/debs vscodium main'


### PR DESCRIPTION
Addresses https://github.com/VSCodium/vscodium.github.io/pull/50#issuecomment-914573872.

When the CSS doesn't artificially change the natural behavior of `<pre>` we can keep related surprising results to a minimum.

Fixes what #44 tried to address in a hopefully more resilient way.