### PR TITLE
Add bash label and --classic flag to snap install

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -51,8 +51,8 @@ scoop install vscodium
 ### <a tabindex="-1" aria-hidden="true" id="install-with-snap" href="#install-with-snap"></a>Install with snap (Linux)
 VSCodium is available in the [Snap Store](https://snapcraft.io/) as [Codium](https://snapcraft.io/codium), published by the [Snapcrafters](https://github.com/snapcrafters/codium) community.
 If your GNU/Linux distribution has support for [snaps](https://snapcraft.io/docs/installing-snapd):
-```
-snap install codium
+```bash
+snap install codium --classic
 ```
 
 ---


### PR DESCRIPTION
Using the `snap install codium` command as is currently on the website doesn't work, giving this error:

```
error: This revision of snap "codium" was published using classic confinement
       and thus may perform arbitrary system changes outside of the security
       sandbox that snaps are usually confined to, which may put your system at
       risk.

       If you understand and want to proceed repeat the command including
       --classic.
```
One should include the `--classic` flag on the website to make the install process more smooth.

Additionally, I've added the `bash` label to the code block to make it consistent with the rest of the site.