### PR TITLE
Home: Use the VSCodium logo at the top

### DIFF
--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -5,17 +5,18 @@ color: black
 style: center
 ---
 
+![VSCodium logo](img/code.png){: width="200"}
+# VSCodium
 ### Free/Libre Open Source Software Binaries of VS Code
 {: .text-purple}
-
-<span style="font-size:100px; background:rgba(255,166,0,0.1)">
-  <img alt="screenshot" src="img/vscodium.png" />
-</span>
-
-### VSCodium is a community-driven, freely-licensed binary distribution of Microsoft's editor VS Code.
 
 [![current release](https://img.shields.io/github/release/vscodium/vscodium.svg)](https://github.com/vscodium/vscodium/releases)
 [![windows_build_status](https://dev.azure.com/vscodium/VSCodium/_apis/build/status/VSCodium.vscodium?branchName=master)](https://dev.azure.com/vscodium/VSCodium/_build?definitionId=1)
 [![build status](https://travis-ci.com/VSCodium/vscodium.svg?branch=master)](https://travis-ci.com/VSCodium/vscodium) 
 [![license](https://img.shields.io/github/license/VSCodium/vscodium.svg)](https://github.com/VSCodium/vscodium/blob/master/LICENSE)
 [![Gitter](https://img.shields.io/gitter/room/vscodium/vscodium.svg)](https://gitter.im/VSCodium/Lobby)
+
+VSCodium is a community-driven, freely-licensed binary distribution of Microsoft's editor VS Code.
+
+![Screenshot](img/vscodium.png)
+

--- a/_posts/2000-01-01-intro.md
+++ b/_posts/2000-01-01-intro.md
@@ -5,17 +5,16 @@ color: black
 style: center
 ---
 
-### Free/Libre Open Source Software Binaries of VSCode
+### Free/Libre Open Source Software Binaries of VS Code
 {: .text-purple}
 
 <span style="font-size:100px; background:rgba(255,166,0,0.1)">
   <img alt="screenshot" src="img/vscodium.png" />
 </span>
 
-### VSCodium is a community-driven, freely-licensed binary distribution of Microsoft's editor VSCode
+### VSCodium is a community-driven, freely-licensed binary distribution of Microsoft's editor VS Code.
 
-
-  [![current release](https://img.shields.io/github/release/vscodium/vscodium.svg)](https://github.com/vscodium/vscodium/releases)
+[![current release](https://img.shields.io/github/release/vscodium/vscodium.svg)](https://github.com/vscodium/vscodium/releases)
 [![windows_build_status](https://dev.azure.com/vscodium/VSCodium/_apis/build/status/VSCodium.vscodium?branchName=master)](https://dev.azure.com/vscodium/VSCodium/_build?definitionId=1)
 [![build status](https://travis-ci.com/VSCodium/vscodium.svg?branch=master)](https://travis-ci.com/VSCodium/vscodium) 
 [![license](https://img.shields.io/github/license/VSCodium/vscodium.svg)](https://github.com/VSCodium/vscodium/blob/master/LICENSE)

--- a/_posts/2000-01-04-why.md
+++ b/_posts/2000-01-04-why.md
@@ -13,4 +13,4 @@ Microsoft's `vscode` source code is open source (MIT-licensed), but the product 
 
 The VSCodium project exists so that you don't have to download+build from source. This project includes special build scripts that clone Microsoft's vscode repo, run the build commands, and upload the resulting binaries for you to [GitHub releases](https://github.com/VSCodium/vscodium/releases). __These binaries are licensed under the MIT license. Telemetry is disabled.__
 
-If you want to build from source yourself, head over to [Microsoft's vscode repo](https://github.com/Microsoft/vscode) and follow their [instructions](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#build-and-run). VSCodium exists to make it easier to get the latest version of MIT-licensed VSCode.
+If you want to build from source yourself, head over to [Microsoft's vscode repo](https://github.com/Microsoft/vscode) and follow their [instructions](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#build-and-run). VSCodium exists to make it easier to get the latest version of MIT-licensed VS Code.


### PR DESCRIPTION
The current homepage (see [this screenshot](https://user-images.githubusercontent.com/4561733/136463632-13397b94-fb74-4ac0-9d44-1c76f6a1f847.png)) starts rather abruptly, as if it's missing a header. This addition inserts the project logo and title into the top of `_posts/2000-01-01-intro.md`, thus making it look a little more like [the README.md of the main repository](https://github.com/VSCodium/vscodium#readme).

Also changes some instances where "VS Code" was spelled as "VSCode" 

## Screenshot

<img width="600" alt="Screenshot" src="https://user-images.githubusercontent.com/4561733/136463706-44d89bd4-6768-4e71-9f0f-b3dd75b26d19.png">
