### PR TITLE
install re-arranged

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -13,31 +13,44 @@ color: black
 
 ---
 
-## Use a Package Manager
+## Use a Package Manager (providing VSCodium in their repository)
 
+The following package managers use their own repository, in case of any installation issues report to their related repository.
+
+---
+
+<a tabindex="-1" aria-hidden="true" id="brew" href="#brew"></a>
 ### Install with Brew (Mac)
 If you are on a Mac and have [Homebrew](https://brew.sh/) installed:
 ```bash
 brew install --cask vscodium
 ```
 
----
-
 _Note for Mac OS X Mojave users: if you see "App can't be opened because Apple cannot check it for malicious software" when opening VSCodium the first time, you can right-click the application and choose Open. This should only be required the first time opening on Mojave._
 
+---
+
+<a tabindex="-1" aria-hidden="true" id="winget" href="#winget"></a>
 ### Install with Windows Package Manager (WinGet)
 If you use Windows and have [Windows Package Manager](https://github.com/microsoft/winget-cli) installed:
 ```bash
 winget install vscodium
 ```
 
+---
+
+<a tabindex="-1" aria-hidden="true" id="chocolatey" href="#chocolatey"></a>
 ### Install with Chocolatey (Windows)
 If you use Windows and have [Chocolatey](https://chocolatey.org) installed (thanks to [@Thilas](https://github.com/Thilas)):
 ```bash
 choco install vscodium
 ```
 
-### <a tabindex="-1" aria-hidden="true" id="install-with-scoop" href="#install-with-scoop"></a>Install with Scoop (Windows)
+---
+
+<a tabindex="-1" aria-hidden="true" id="install-with-scoop" href="#install-with-scoop"></a>
+<a tabindex="-1" aria-hidden="true" id="scoop" href="#scoop"></a>
+### Install with Scoop (Windows)
 If you use Windows and have [Scoop](https://scoop.sh/) installed:
 ```bash
 scoop bucket add extras
@@ -48,7 +61,9 @@ scoop install vscodium
 
 ---
 
-### <a tabindex="-1" aria-hidden="true" id="install-with-snap" href="#install-with-snap"></a>Install with snap (Linux)
+<a tabindex="-1" aria-hidden="true" id="install-with-snap" href="#install-with-snap"></a>
+<a tabindex="-1" aria-hidden="true" id="snap" href="#snap"></a>
+### Install with snap (Linux)
 VSCodium is available in the [Snap Store](https://snapcraft.io/) as [Codium](https://snapcraft.io/codium), published by the [Snapcrafters](https://github.com/snapcrafters/codium) community.
 If your GNU/Linux distribution has support for [snaps](https://snapcraft.io/docs/installing-snapd):
 ```bash
@@ -57,10 +72,8 @@ snap install codium --classic
 
 ---
 
-### Install with Package Manager (Linux)
-
-
-#### Parrot OS:
+<a tabindex="-1" aria-hidden="true" id="parrot" href="#parrot"></a>
+### Install on Parrot OS:
 
 VSCodium is pre-installed in Parrot OS.
 
@@ -72,12 +85,45 @@ sudo apt update && sudo apt install codium
 
 ---
 
+<a tabindex="-1" aria-hidden="true" id="nix" href="#nix"></a>
+### Install on Nix(OS)
+
+VSCodium is available in Nixpkgs. You can install it by adding `vscodium` to `environment.systemPackages` in `configuration.nix`, or locally:
+
+```bash
+nix-env -iA nixpkgs.vscodium
+```
+
+---
+
+<a tabindex="-1" aria-hidden="true" id="arch" href="#arch"></a>
+### Install on Arch Linux
+
+VSCodium is available on the [AUR (Arch User Repository)](https://aur.archlinux.org/packages/vscodium-bin/), and can be installed with an AUR Helper.
+
+Examples:
+
+- **Aura**:
+  ```
+  sudo aura -A vscodium-bin
+  ```
+- **Yay**:
+  ```
+  yay -S vscodium-bin
+  ```
+
+
+## Use a Package Manager (dep/rpm, provided by VSCodium related repository)
+
 [@paulcarroty](https://github.com/paulcarroty) has set up a [repository](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo) for VSCodium. The instructions below are adapted from there with [CDN](https://download.vscodium.com) mirror. Any issues installing VSCodium using your package manager should be directed to that repository's issue tracker.
 
 [@jtagcat](https://github.com/jtagcat) set up an hourly [mirror](https://vscodium.c7.ee) of [@paulcarroty](https://github.com/paulcarroty)'s repository.  
 To use the mirror, you may replace `paulcarroty.gitlab.io/vscodium-deb-rpm-repo` with `vscodium.c7.ee` in your package manager configuration.
 
-#### Debian / Ubuntu (deb package):
+---
+
+<a tabindex="-1" aria-hidden="true" id="deb" href="#deb"></a>
+### Install on Debian / Ubuntu (deb package):
 Add the GPG key of the repository:
 ```bash
 wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg \
@@ -96,11 +142,10 @@ Update then install vscodium (if you want vscodium-insiders, then replace `codiu
 sudo apt update && sudo apt install codium
 ```
 
-
 ---
 
-
-#### Fedora / Centos / OpenSUSE (rpm package):
+<a tabindex="-1" aria-hidden="true" id="rpm" href="#rpm"></a>
+### Install on Fedora / RHEL / CentOS / RockyLinux / OpenSUSE (rpm package):
 
 Add the GPG key of the repository:
 
@@ -110,12 +155,12 @@ sudo rpmkeys --import https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/raw
 
 Add the repository:
 
-- **Fedora/RHEL**:
+- **Fedora/RHEL/CentOS/Rocky Linux**:
   ```bash
   printf "[gitlab.com_paulcarroty_vscodium_repo]\nname=download.vscodium.com\nbaseurl=https://download.vscodium.com/rpms/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/raw/master/pub.gpg\nmetadata_expire=1h" | sudo tee -a /etc/yum.repos.d/vscodium.repo
   ```
 
-- **openSUSE/SUSE**:
+- **OpenSUSE/SUSE**:
   ```bash
   printf "[gitlab.com_paulcarroty_vscodium_repo]\nname=gitlab.com_paulcarroty_vscodium_repo\nbaseurl=https://download.vscodium.com/rpms/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/raw/master/pub.gpg\nmetadata_expire=1h" | sudo tee -a /etc/zypp/repos.d/vscodium.repo
   ```
@@ -124,7 +169,7 @@ Add the repository:
 Install the software:
 (if you want vscodium-insiders, then replace `codium` by `codium-insiders`)
 
-- **Fedora/RHEL**:
+- **Fedora/RHEL/CentOS/Rocky Linux**:
   ```
   sudo dnf install codium
   ```
@@ -133,32 +178,9 @@ Install the software:
   sudo zypper in codium
   ```
 
----
 
-#### Nix(OS)
-
-VSCodium is available in Nixpkgs. You can install it by adding `vscodium` to `environment.systemPackages` in `configuration.nix`, or locally:
-
-```bash
-nix-env -iA nixpkgs.vscodium
-```
-
-#### Arch Linux
-
-VSCodium is available on the [AUR (Arch User Repository)](https://aur.archlinux.org/packages/vscodium-bin/), and can be installed with an AUR Helper.
-
-Examples:
-
-- **Aura**:
-  ```
-  sudo aura -A vscodium-bin
-  ```
-- **Yay**:
-  ```
-  yay -S vscodium-bin
-  ```
-
-### <a tabindex="-1" aria-hidden="true" id="flatpak" href="#flatpak"></a>Flatpak Option (Linux)
+<a tabindex="-1" aria-hidden="true" id="flatpak" href="#flatpak"></a>
+## Flatpak Option (Linux)
 VSCodium is (unofficially) available as a [Flatpak app](https://flathub.org/apps/details/com.vscodium.codium) and here's the [build repo](https://github.com/flathub/com.vscodium.codium). If your distribution has support for [flatpak](https://flathub.org), and you have enabled the [flathub repo](https://flatpak.org/setup/), you can install VSCodium via the command line:
 ```bash
 flatpak install flathub com.vscodium.codium


### PR DESCRIPTION
* re-grouped as "external/VSCodium related/flatpak"
* added anchor links before each option (using those will show the appropriate header in most browsers)
* adjusted rpm Distros