### PR TITLE
Revert "install: add a note of a mirror (#53)"

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -117,9 +117,6 @@ Examples:
 
 [@paulcarroty](https://github.com/paulcarroty) has set up a [repository](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo) for VSCodium. The instructions below are adapted from there with [CDN](https://download.vscodium.com) mirror. Any issues installing VSCodium using your package manager should be directed to that repository's issue tracker.
 
-[@jtagcat](https://github.com/jtagcat) set up an hourly [mirror](https://vscodium.c7.ee) of [@paulcarroty](https://github.com/paulcarroty)'s repository.  
-To use the mirror, you may replace `paulcarroty.gitlab.io/vscodium-deb-rpm-repo` with `vscodium.c7.ee` in your package manager configuration.
-
 ---
 
 <a tabindex="-1" aria-hidden="true" id="deb" href="#deb"></a>


### PR DESCRIPTION
This reverts commit 5d1fa4702db5ec0d9f87e0beb9d2160c36746a17.

GitLab made changes, breaking the current mirroring setup. I no longer actively use my own mirror, and as such lack interest in reviving it.

https://web.archive.org/web/20221226011455/https://vscodium.c7.ee/