### PR TITLE
fix homepage docs link [for #79]

### DIFF
--- a/_posts/2000-01-06-moreinfo.md
+++ b/_posts/2000-01-06-moreinfo.md
@@ -5,4 +5,4 @@ color: black
 ---
 
 # More Info
-The most up-to-date information on migrating from Visual Studio Code and other quirks you might encounter are [documented](https://github.com/VSCodium/vscodium/blob/master/DOCS.md).
+The most up-to-date information on migrating from Visual Studio Code and other quirks you might encounter are [documented](https://github.com/VSCodium/vscodium/blob/master/docs/index.md).


### PR DESCRIPTION
- Fixes #79

Points the "more info" link to the correct URL