### PR TITLE
Specified architecture for Debian / Ubuntu

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -130,7 +130,7 @@ wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.g
 
 Add the repository:
 ```bash
-echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg] https://download.vscodium.com/debs vscodium main' \
+echo 'deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg] https://download.vscodium.com/debs vscodium main' \
     | sudo tee /etc/apt/sources.list.d/vscodium.list
 ```
 

--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -130,7 +130,7 @@ wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.g
 
 Add the repository:
 ```bash
-echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg ] https://download.vscodium.com/debs vscodium main' \
+echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg] https://download.vscodium.com/debs vscodium main' \
     | sudo tee /etc/apt/sources.list.d/vscodium.list
 ```
 


### PR DESCRIPTION
It seems that the repository `https://download.vscodium.com/debs vscodium main` does not have any other architecture other than `amd64`.
Specifying the architecture removes the warning about the missing architecture when executing `apt update` if the user has the `i386` architecture on his machine (for example, if he has `steam` installed).