### PR TITLE
Update install section for Debian Trixie / Ubuntu 24.04 Sources Format

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -129,10 +129,16 @@ wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.g
 ```
 
 Add the repository:
-```bash
-echo 'deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg] https://download.vscodium.com/debs vscodium main' \
-    | sudo tee /etc/apt/sources.list.d/vscodium.list
-```
+- **Debian 13 / Ubuntu 24.04 or newer**
+  ```bash
+  echo -e 'Types: deb\nURIs: https://download.vscodium.com/debs\nSuites: vscodium\nComponents: main\nArchitectures: amd64 arm64\nSigned-by: /usr/share/keyrings/vscodium-archive-keyring.gpg' \
+  | sudo tee /etc/apt/sources.list.d/vscodium.sources
+  ```
+- **Debian 12 / Ubuntu 23.10 or older**:
+  ```bash
+  echo 'deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg] https://download.vscodium.com/debs vscodium main' \
+      | sudo tee /etc/apt/sources.list.d/vscodium.list
+  ```
 
 Update then install vscodium (if you want vscodium-insiders, then replace `codium` by `codium-insiders`):
 ```bash


### PR DESCRIPTION
The ```sources.list``` file format has been officially superseded by the deb822 ```debian.sources``` format as of Debian 13 Trixie and Ubuntu 24.04 (see https://wiki.debian.org/SourcesList); while the old format isn't yet deprecated, it'd probably be wise to direct users to use the new default format. Thus, I have Debian/Ubuntu section to reflect this.

I opted to add the new method as the one for Debian 13 / Ubuntu 24.04 or later, while leaving the old method as the one for Debian 12 / Ubuntu 23.10 or older so that the sources file matches the system default; however, the new format seems to have been supported for several years before it became default (since roughly Debian Stretch), so if you wanted, I could even make a commit and just get rid of the old method entirely.