### PR TITLE
Add paru to installation instructions for Arch Linux

### DIFF
--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -111,6 +111,10 @@ Examples:
   ```
   yay -S vscodium-bin
   ```
+- **Paru**:
+  ```
+  paru -S vscodium-bin
+  ```
 
 
 ## Use a Package Manager (deb/rpm, provided by VSCodium related repository)


### PR DESCRIPTION
[Paru](https://github.com/Morganamilo/paru) is a popular AUR helper widely used by many Arch Linux users.