### PR TITLE
Fix rpm repo instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 _site/
+frontmatter.json
+taxonomyDb.json
+pinnedItemsDb.json

--- a/_posts/2000-01-05-install.md
+++ b/_posts/2000-01-05-install.md
@@ -150,22 +150,34 @@ sudo apt update && sudo apt install codium
 <a tabindex="-1" aria-hidden="true" id="rpm" href="#rpm"></a>
 ### Install on Fedora / RHEL / CentOS / RockyLinux / OpenSUSE (rpm package):
 
-Add the GPG key of the repository:
-
-```bash
-sudo rpmkeys --import https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/raw/master/pub.gpg
-```
-
 Add the repository:
 
 - **Fedora/RHEL/CentOS/Rocky Linux**:
-  ```bash
-  printf "[gitlab.com_paulcarroty_vscodium_repo]\nname=download.vscodium.com\nbaseurl=https://download.vscodium.com/rpms/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/raw/master/pub.gpg\nmetadata_expire=1h\n" | sudo tee -a /etc/yum.repos.d/vscodium.repo
+  ```
+sudo tee -a /etc/yum.repos.d/vscodium.repo << 'EOF'
+[gitlab.com_paulcarroty_vscodium_repo]
+name=gitlab.com_paulcarroty_vscodium_repo
+baseurl=https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/rpms/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
+metadata_expire=1h
+EOF
   ```
 
 - **OpenSUSE/SUSE**:
-  ```bash
-  printf "[gitlab.com_paulcarroty_vscodium_repo]\nname=gitlab.com_paulcarroty_vscodium_repo\nbaseurl=https://download.vscodium.com/rpms/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/raw/master/pub.gpg\nmetadata_expire=1h\n" | sudo tee -a /etc/zypp/repos.d/vscodium.repo
+  ```
+sudo tee -a /etc/zypp/repos.d/vscodium.repo << 'EOF'
+[gitlab.com_paulcarroty_vscodium_repo]
+name=gitlab.com_paulcarroty_vscodium_repo
+baseurl=https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/rpms/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
+metadata_expire=1h
+EOF
   ```
 
 


### PR DESCRIPTION
The current instructions for the configuration of @paulcarroty's rpm repo is out of date - on my machine, attempting this config throws permanent errors attempting to access the malconfigured repo. I have simply updated the instructions to match Paul's current instructions [here](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo), which do work, and on an install from which I added this commit.

I don't have a Debian install and don't want to bother creating a VM, so others may hope to check the deb repo and add an update if needed.